### PR TITLE
Hotfix/nfc scanner

### DIFF
--- a/Software/api/src/main/java/org/foi/air/api/network/ApiService.kt
+++ b/Software/api/src/main/java/org/foi/air/api/network/ApiService.kt
@@ -7,9 +7,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 object ApiService {
 
-    private const val BASE_URL = "http://baccboysapi.onrender.com/"
-
-
+    private const val BASE_URL = "https://baccboysapi.onrender.com/"
     var authToken : String = ""
 
     private val interceptor = Interceptor {

--- a/Software/app/src/main/java/org/foi/air/smartcharger/fragments/ChargerConnectionFragment.kt
+++ b/Software/app/src/main/java/org/foi/air/smartcharger/fragments/ChargerConnectionFragment.kt
@@ -6,7 +6,6 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.core.content.ContextCompat
 import com.example.nfc_scanner.NfcScanner
 import org.foi.air.core.interfaces.OnNewIntentListener
@@ -46,7 +45,7 @@ class ChargerConnectionFragment : Fragment() {
                     btnConnectBg()
                 }
             } else {
-                Toast.makeText(requireContext(), getString(R.string.please_active_nfc), Toast.LENGTH_SHORT).show()
+                binding.tvStatus.text = resources.getString(R.string.please_active_nfc)
             }
         }
         return binding.root

--- a/Software/app/src/main/res/values/strings.xml
+++ b/Software/app/src/main/res/values/strings.xml
@@ -52,7 +52,7 @@
     <string name="close_drawer">Close Drawer</string>
     <string name="header_name">%1$s %2$s</string>
     <string name="scan_card">Scan card</string>
-    <string name="please_active_nfc">Please active NFC</string>
+    <string name="please_active_nfc">Please activate NFC</string>
     <string name="please_scan_your_card_first">Please scan your card first!</string>
 
 

--- a/Software/nfc_scanner/src/main/java/com/example/nfc_scanner/NfcScanner.kt
+++ b/Software/nfc_scanner/src/main/java/com/example/nfc_scanner/NfcScanner.kt
@@ -7,8 +7,6 @@ import android.nfc.NfcAdapter
 import android.nfc.Tag
 import android.nfc.tech.MifareClassic
 import android.util.Log
-import android.widget.Toast
-import org.foi.hr.nfc_scanner.R
 
 class NfcScanner(private val activity: Activity) {
     private var nfcAdapter: NfcAdapter? = null
@@ -24,10 +22,6 @@ class NfcScanner(private val activity: Activity) {
         try {
             nfcAdapter = NfcAdapter.getDefaultAdapter(activity)
 
-            if(nfcAdapter?.isEnabled!!){
-                Toast.makeText(activity.baseContext,
-                    activity.baseContext.getString(R.string.this_device_doesn_t_support_nfc),Toast.LENGTH_SHORT).show()
-            }
             val intent = Intent(activity, javaClass).apply {
                 addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
             }
@@ -80,7 +74,11 @@ class NfcScanner(private val activity: Activity) {
     }
 
     fun getNfcAdapterStatus(): Boolean {
-        if (nfcAdapter != null && nfcAdapter!!.isEnabled) return true
+        if (nfcAdapter != null && nfcAdapter!!.isEnabled) {
+            onResume()
+            return true
+        }
+        onPause()
         return false
     }
 }


### PR DESCRIPTION
Fixed following problems:

- Switched API url address from http to https
- Fixed visual problems with dialog window for adding new cards
- Refactored toast error messages to error messages on the related pages (keeping up the consistency of displaying errors and other UI elements)
- Fixed problem when turning off NFC and turning it back on, it wouldn't scan RFID cards.